### PR TITLE
add flatpak & snap support; error discord not running; rewrite on reconnect

### DIFF
--- a/client_unix.go
+++ b/client_unix.go
@@ -3,6 +3,8 @@
 package drpc
 
 import (
+	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -32,11 +34,15 @@ func connect() (net.Conn, error) {
 				filepath.Join(temp, sd, "discord-ipc-"+strconv.Itoa(i)),
 				time.Second*5,
 			)
+			// socket exists, but it has a error.
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("%w: %w", ErrConnFailed, err)
+			}
 			if err == nil {
 				return conn, nil
 			}
 		}
 	}
 
-	return nil, ErrConnFailed
+	return nil, errors.New("drpc: discord is not running")
 }

--- a/client_unix.go
+++ b/client_unix.go
@@ -3,7 +3,6 @@
 package drpc
 
 import (
-	"errors"
 	"net"
 	"os"
 	"path/filepath"
@@ -13,6 +12,12 @@ import (
 
 func connect() (net.Conn, error) {
 	temp := "/tmp"
+	subDirs := []string{
+		"",
+		"app/com.discordapp.Discord",
+		"snap.discord",
+	}
+
 	for _, name := range []string{"XDG_RUNTIME_DIR", "TMPDIR", "TMP", "TEMP"} {
 		if value := os.Getenv(name); value != "" {
 			temp = value
@@ -20,16 +25,18 @@ func connect() (net.Conn, error) {
 		}
 	}
 
-	for i := 0; i < 10; i++ {
-		conn, err := net.DialTimeout(
-			"unix",
-			filepath.Join(temp, "discord-ipc-"+strconv.Itoa(i)),
-			time.Second*5,
-		)
-		if err == nil {
-			return conn, nil
+	for _, sd := range subDirs {
+		for i := 0; i < 10; i++ {
+			conn, err := net.DialTimeout(
+				"unix",
+				filepath.Join(temp, sd, "discord-ipc-"+strconv.Itoa(i)),
+				time.Second*5,
+			)
+			if err == nil {
+				return conn, nil
+			}
 		}
 	}
 
-	return nil, errors.New("drpc: connection failed")
+	return nil, ErrConnFailed
 }

--- a/client_win.go
+++ b/client_win.go
@@ -22,5 +22,5 @@ func connect() (net.Conn, error) {
 		}
 	}
 
-	return nil, errors.New("drpc: connection failed")
+	return nil, ErrConnFailed
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/altfoxie/drpc
 go 1.17
 
 require (
-	github.com/google/uuid v1.3.0
+	github.com/google/uuid v1.5.0
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=


### PR DESCRIPTION
This PR adds the paths necessary for which Flatpak and Snap give Discord a IPC to interact with.

Additionally, reconnection support has been dropped as it can be seen as undefined behavior.

I wanted to implement errors for when socket establishment fails, but for me seems too complicated.

If you would like, i can retain the reconnection support.