### PR TITLE
minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ $ go get -u github.com/altfoxie/drpc
 ## Usage
 You need to create a client.
 ```go
-client, err := drpc.New("APP_ID")
-if err != nil { /* handle error */ }
+client := drpc.New("APP_ID")
 ```
 
 Now you can use the client to set player's activity. DRPC maintains a persistent connection to Discord RPC, so you don't need to worry about reconnecting.

--- a/client_win.go
+++ b/client_win.go
@@ -4,6 +4,7 @@ package drpc
 
 import (
 	"net"
+	"os"
 	"strconv"
 	"time"
 
@@ -21,5 +22,5 @@ func connect() (net.Conn, error) {
 		}
 	}
 
-	return nil, ErrConnFailed
+	return nil, os.ErrNotExist
 }

--- a/example/main.go
+++ b/example/main.go
@@ -7,12 +7,9 @@ import (
 )
 
 func main() {
-	client, err := drpc.New("975346661540909056")
-	if err != nil {
-		panic(err)
-	}
+	client := drpc.New("975346661540909056")
 
-	err = client.SetActivity(drpc.Activity{
+	err := client.SetActivity(drpc.Activity{
 		Details: "Details",
 		State:   "State",
 		Timestamps: &drpc.Timestamps{


### PR DESCRIPTION
just some code style changes, adhering to Go's code style.

The choice of not prefixing errors comes from making errors more clear instead of knowing which package it came from.